### PR TITLE
dark thin scrollbars

### DIFF
--- a/theme_kibanafeel.css
+++ b/theme_kibanafeel.css
@@ -25,6 +25,17 @@ Released under the terms of the MIT license
     --shadow-standard: 0 2px 2px -1px rgba(0, 0, 0, 0.3)
 }
 
+::-webkit-scrollbar {
+  width: 9px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(155, 155, 155, 0.5);
+  border-radius: 20px;
+  border: transparent;
+}
 
 /* Root Styles */
 body {


### PR DESCRIPTION
make scrollbars thin and dark to better fit with the theme (only tested in chrome) shamelessly stolen from https://stackoverflow.com/questions/66166047/how-to-make-thin-scrollbar-in-chrome

before:
![image](https://github.com/gamersoutreach/librenms-kibanafeel/assets/30209689/263e4a9c-796b-4240-abe2-bf1b59be328b)


after:
![image](https://github.com/gamersoutreach/librenms-kibanafeel/assets/30209689/e2d3df41-8bd6-4c92-8baa-1ad7ac5229cd)
